### PR TITLE
Comments on params, stopping criteria for n_splats

### DIFF
--- a/arguments/__init__.py
+++ b/arguments/__init__.py
@@ -70,22 +70,23 @@ class PipelineParams(ParamGroup):
 
 class OptimizationParams(ParamGroup):
     def __init__(self, parser):
-        self.iterations = 15_000
-        self.position_lr_init = 0.00016
-        self.position_lr_final = 0.0000016
-        self.position_lr_delay_mult = 0.01
-        self.position_lr_max_steps = 30_000
-        self.feature_lr = 0.0025
-        self.opacity_lr = 0.05
-        self.scaling_lr = 0.005
-        self.rotation_lr = 0.001
-        self.percent_dense = 0.01
-        self.lambda_dssim = 0.2
-        self.densification_interval = 100
-        self.opacity_reset_interval = 3000
-        self.densify_from_iter = 500
-        self.densify_until_iter = 15_000
-        self.densify_grad_threshold = 0.0002
+        self.max_num_splats = 3_000_000 # Stop densifying after this number of splats is reached
+        self.iterations = 15_000 # [default 30_000] Each iteration corresponds to reconstructing 1 image. The number of points being optimized increases over
+        self.position_lr_init = 0.00016 # [default 0.00016] Learning rate should be smaller for more extensive scenes
+        self.position_lr_final = 0.0000016 # [default 0.0000016] Learning rate should be smaller for more extensive scenes
+        self.position_lr_delay_mult = 0.01 # [default 0.01]
+        self.position_lr_max_steps = 30_000 # [default 30_000]
+        self.feature_lr = 0.0025 # [default 0.0025]
+        self.opacity_lr = 0.05 # [default 0.05]
+        self.scaling_lr = 0.005 # [default 0.005]
+        self.rotation_lr = 0.001 # [default 0.001]
+        self.percent_dense = 0.01 # [default 0.01] percent_dense * scene_extent = threshold size to determine whether to split (current is too large) or clone (current is small) gaussian
+        self.lambda_dssim = 0.2 # [default 0.2] Loss = (1-lambda) * L1_loss + lambda * D-SSIM_Loss. L1 = abs(pred_pixel - true_pixel). SSIM = similarity between 2 images (luminance, contrast, structure)
+        self.densification_interval = 100 # [default 100] Increase this to avoid running out of memory (how many iterations in between densifying/splitting gaussians)
+        self.opacity_reset_interval = 1000 # [default 3000] Decrease all opacities (alpha) close to zero -> algo will automatically increase opacities again for important gaussians -> cull the rest
+        self.densify_from_iter = 500 # [default 500] After this many iterations, start densifying
+        self.densify_until_iter = 0.5 * self.iterations # [default 15_000] Decrease this to avoid running out of memory (after this many iterations, stop densifying)
+        self.densify_grad_threshold = 0.0002 # [default 0.0002; Section 5.2: tau_pos] Increase this to avoid running out of memory. If very high, no densification will occur
         super().__init__(parser, "Optimization Parameters")
 
 def get_combined_args(parser : ArgumentParser):

--- a/arguments/__init__.py
+++ b/arguments/__init__.py
@@ -71,7 +71,7 @@ class PipelineParams(ParamGroup):
 class OptimizationParams(ParamGroup):
     def __init__(self, parser):
         self.max_num_splats = 3_000_000 # Stop densifying after this number of splats is reached
-        self.iterations = 15_000 # [default 30_000] Each iteration corresponds to reconstructing 1 image. The number of points being optimized increases over
+        self.iterations = 10_000 # [default 30_000] Each iteration corresponds to reconstructing 1 image. The number of points being optimized increases over
         self.position_lr_init = 0.00016 # [default 0.00016] Learning rate should be smaller for more extensive scenes
         self.position_lr_final = 0.0000016 # [default 0.0000016] Learning rate should be smaller for more extensive scenes
         self.position_lr_delay_mult = 0.01 # [default 0.01]
@@ -86,7 +86,9 @@ class OptimizationParams(ParamGroup):
         self.opacity_reset_interval = 1000 # [default 3000] Decrease all opacities (alpha) close to zero -> algo will automatically increase opacities again for important gaussians -> cull the rest
         self.densify_from_iter = 500 # [default 500] After this many iterations, start densifying
         self.densify_until_iter = 0.5 * self.iterations # [default 15_000] Decrease this to avoid running out of memory (after this many iterations, stop densifying)
-        self.densify_grad_threshold = 0.0002 # [default 0.0002; Section 5.2: tau_pos] Increase this to avoid running out of memory. If very high, no densification will occur
+        self.densify_grad_threshold_init = 0.0002 # [default 0.0002; Section 5.2: tau_pos] Increase this to avoid running out of memory. If very high, no densification will occur
+        self.densify_grad_threshold_final = 0.002 # See densify_grad_threshold_start_increase
+        self.densify_grad_threshold_start_increase = 0.6 # [0-1] Start increasing densify_grad_threshold from init -> final once there are densify_grad_threshold_start_increase * max_num_splats of splats
         super().__init__(parser, "Optimization Parameters")
 
 def get_combined_args(parser : ArgumentParser):

--- a/arguments/__init__.py
+++ b/arguments/__init__.py
@@ -85,7 +85,8 @@ class OptimizationParams(ParamGroup):
         self.densification_interval = 100 # [default 100] Increase this to avoid running out of memory (how many iterations in between densifying/splitting gaussians)
         self.opacity_reset_interval = 1000 # [default 3000] Decrease all opacities (alpha) close to zero -> algo will automatically increase opacities again for important gaussians -> cull the rest
         self.densify_from_iter = 500 # [default 500] After this many iterations, start densifying
-        self.densify_until_iter = 0.5 * self.iterations # [default 15_000] Decrease this to avoid running out of memory (after this many iterations, stop densifying)
+        self.densify_until_iter = 0.8 * self.iterations # [default 15_000] After this many iterations, stop densification
+        self.densify_until_iter_start_increase = 0.5 * self.iterations # After this many iterations, make it harder to densify (value should be lower than densify_until_iter)
         self.densify_grad_threshold_init = 0.0002 # [default 0.0002; Section 5.2: tau_pos] Increase this to avoid running out of memory. If very high, no densification will occur
         self.densify_grad_threshold_final = 0.002 # See densify_grad_threshold_start_increase
         self.densify_grad_threshold_start_increase = 0.6 # [0-1] Start increasing densify_grad_threshold from init -> final once there are densify_grad_threshold_start_increase * max_num_splats of splats


### PR DESCRIPTION
- Added comments to each parameter in __init__.py
- Added max_num_splats parameter -> stop densifying when surpass this threshold. Additionally, added parameters to gradually slow down densification when it is getting close to the threshold (see plot below approaching 1M splats)
- Also slow down densification as we approach the place where densification stops (based on a number of iterations)
- Made opacity_reset_interval more frequent
- Print out more information
- Stop at 10,000 iterations instead of 15,000
- Don't save progress at 7,000 iterations anymore - just at the end

<img width="675" alt="Screenshot 2023-09-27 at 10 15 47 AM" src="https://github.com/PolyCam/radiance/assets/56136011/f9316e6c-a864-4216-8476-0869abf3819e">
